### PR TITLE
Close HttpURLConnections

### DIFF
--- a/src/main/java/io/keen/client/java/KeenHttpRequestRunnable.java
+++ b/src/main/java/io/keen/client/java/KeenHttpRequestRunnable.java
@@ -15,9 +15,9 @@ import java.util.Map;
  */
 class KeenHttpRequestRunnable implements Runnable {
     private static final int READ_TIMEOUT = 60000;
-	private static final int CONNECT_TIMEOUT = 60000;
-	
-	private final KeenClient keenClient;
+    private static final int CONNECT_TIMEOUT = 60000;
+    
+    private final KeenClient keenClient;
     private final String eventCollection;
     private final Map<String, Object> event;
     private final AddEventCallback callback;
@@ -35,9 +35,9 @@ class KeenHttpRequestRunnable implements Runnable {
             HttpURLConnection connection = sendEvent(this.eventCollection, this.event);
             InputStream inputStream = connection.getInputStream();
             try {
-            	handleResult(inputStream, connection.getResponseCode(), callback);
+                handleResult(inputStream, connection.getResponseCode(), callback);
             } finally {
-            	inputStream.close();
+                inputStream.close();
             }
         } catch (IOException e) {
             KeenLogging.log("There was an error while sending events to the Keen API.");


### PR DESCRIPTION
Our production server was crashing with "too many open files". Investigating the open files using lsof I noticed a large number of TCP connections in CLOSE_WAIT to 50.22.16.4-static.reverse.softlayer.com:https or similar. I believe the connections were being left hanging open and thus leaking.

I have added an explicit close on the InputStream and added timeouts on connect and read from the socket. This appears to have resolved the issue in our production environment.
