### PR TITLE
add support for proxy servers

### DIFF
--- a/src/main/java/io/keen/client/java/KeenConfig.java
+++ b/src/main/java/io/keen/client/java/KeenConfig.java
@@ -1,5 +1,8 @@
 package io.keen.client.java;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
 /**
  * KeenConfig
  *
@@ -10,9 +13,30 @@ package io.keen.client.java;
  */
 public class KeenConfig {
 
+    private static Proxy proxy;
     /**
      * How many threads to use to send events to Keen IO. Change this to 0 if you want to manage your own threads.
      */
     public static int NUM_THREADS_FOR_HTTP_REQUESTS = 3;
 
+    /**
+     * Call this to set a HTTP proxy server configuration for all Keen IO communication.
+     *
+     * @param proxyUrl The proxy hostname or IP address.
+     * @param proxyPort  The proxy port number.
+     */
+    public static void setProxy(String proxyUrl, int proxyPort) {
+        proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyUrl, proxyPort));
+    }
+
+    static Proxy getProxy() {
+        return proxy;
+    }
+
+    /**
+     * Call this to clean the currently configured HTTP Proxy server configuration.
+     */
+    public static void clearProxy() {
+        proxy = null;
+    }
 }

--- a/src/test/java/io/keen/client/java/KeenConfigTest.java
+++ b/src/test/java/io/keen/client/java/KeenConfigTest.java
@@ -1,0 +1,37 @@
+package io.keen.client.java;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KeenConfigTest {
+
+    @After
+    public void tearDown() throws Exception {
+        KeenConfig.clearProxy();
+    }
+
+    @Test
+    public void proxyStartOffEmpty() throws Exception {
+        assertNull(KeenConfig.getProxy());
+    }
+
+    @Test
+    public void canConfigureProxyObject() throws Exception {
+
+        KeenConfig.setProxy("foo", 8080);
+
+        assertEquals("foo:8080", KeenConfig.getProxy().address().toString());
+    }
+
+    @Test
+    public void canClearProxy() throws Exception {
+        KeenConfig.setProxy("foo", 8080);
+
+        KeenConfig.clearProxy();
+
+        assertNull(KeenConfig.getProxy());
+    }
+}

--- a/src/test/java/io/keen/client/java/KeenHttpRequestRunnableTest.java
+++ b/src/test/java/io/keen/client/java/KeenHttpRequestRunnableTest.java
@@ -1,0 +1,62 @@
+package io.keen.client.java;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.*;
+
+import static org.junit.Assert.*;
+
+public class KeenHttpRequestRunnableTest {
+
+    private Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("/", 8080));
+
+    @Test
+    public void willUseProxyIfConfigured() throws Exception {
+
+        KeenHttpRequestRunnable request = new KeenHttpRequestRunnable(null,null, null, null, proxy);
+
+        MockHandler handler = new MockHandler();
+
+        URL url = new URL("foo", "bar", 99, "/foobar", handler);
+
+        request.openConnection(url);
+
+        assertTrue(handler.calledWithProxy);
+        assertEquals(proxy, handler.openedProxy);
+    }
+
+    @Test
+    public void noProxyConfiguredWillNotUseAProxy() throws Exception {
+
+        KeenHttpRequestRunnable request = new KeenHttpRequestRunnable(null,null, null, null, null);
+
+        MockHandler handler = new MockHandler();
+
+        URL url = new URL("foo", "bar", 99, "/foobar", handler);
+
+        request.openConnection(url);
+
+        assertTrue(handler.calledWithoutProxy);
+        assertNull(handler.openedProxy);
+    }
+
+    class MockHandler extends URLStreamHandler {
+        boolean calledWithProxy;
+        boolean calledWithoutProxy;
+        Proxy openedProxy;
+
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+            calledWithoutProxy = true;
+            return null;
+        }
+
+        @Override
+        protected URLConnection openConnection(URL u, Proxy p) throws IOException {
+            calledWithProxy = true;
+            openedProxy = p;
+            return null;
+        }
+    };
+}


### PR DESCRIPTION
This resolves issue #12 and adds support for HTTP proxy servers in the Keen IO client. 

A couple of notes:
    1) It does not support authenticated proxies. users can set the authenticator on their own
    2) It currently only supports HTTP proxies (this is the vast majority of users)
    3) Not setting the proxy does not block configuring a container level one.

A note on code:
    I picked constructor injection to get the proxy into KeenHttpRequestRunnable. This was a personal preference. If you would rather I directly reference the static config at the point where it is used I can change it.
