### PR TITLE
Clone the Keen Map if no timestamp. Fix #14.

### DIFF
--- a/core/src/main/java/io/keen/client/java/KeenClient.java
+++ b/core/src/main/java/io/keen/client/java/KeenClient.java
@@ -929,13 +929,11 @@ public class KeenClient {
         if (keenProperties == null) {
             keenProperties = new HashMap<String, Object>();
             keenProperties.put("timestamp", timestamp);
-        } else {
-            if (!keenProperties.containsKey("timestamp")) {
-                // we need to make a copy if we are setting the timestamp since
-                // they might reuse the original keepProperties object. See #14.
-                keenProperties = new HashMap<String, Object>(keenProperties);
-                keenProperties.put("timestamp", timestamp);
-            }
+        } else if (!keenProperties.containsKey("timestamp")) {
+            // we need to make a copy if we are setting the timestamp since
+            // they might reuse the original keepProperties object.
+            keenProperties = new HashMap<String, Object>(keenProperties);
+            keenProperties.put("timestamp", timestamp);
         }
         newEvent.put("keen", keenProperties);
 

--- a/core/src/test/java/io/keen/client/java/KeenClientTest.java
+++ b/core/src/test/java/io/keen/client/java/KeenClientTest.java
@@ -231,11 +231,15 @@ public class KeenClientTest {
         Map<String, Object> event = new HashMap<String, Object>();
         event.put("valid key", "valid value");
         Map<String, Object> keenProperties = new HashMap<String, Object>();
+        keenProperties.put("keen key", "keen value");
         Map<String, Object> result = client.validateAndBuildEvent(client.getDefaultProject(), "foo", event, keenProperties);
         @SuppressWarnings("unchecked")
         Map<String, Object> keenPropResult = (Map<String, Object>)result.get("keen");
         assertNotNull(keenPropResult.get("timestamp"));
         assertNull(keenProperties.get("timestamp"));
+        assertEquals(keenProperties.get("keen key"), "keen value");
+        assertEquals(keenPropResult.get("keen key"), "keen value");
+        assertEquals(keenProperties.get("keen key"), keenPropResult.get("keen key"));
     }
 
     @Test


### PR DESCRIPTION
This is a simple fix for #14. If a timestamp isn't present on the `keenProperties` Map, then it creates a copy of the existing map and sets the timestamp on the copy only, leaving the original untouched.
