### PR TITLE
Add public method to disable the default log handler

### DIFF
--- a/core/src/main/java/io/keen/client/java/KeenLogging.java
+++ b/core/src/main/java/io/keen/client/java/KeenLogging.java
@@ -45,6 +45,14 @@ public class KeenLogging {
     public static void disableLogging() {
         setLogLevel(Level.OFF);
     }
+    
+    /**
+     * Disable the default log handler installed by the Keen Client to allow 
+     * log management by standard j.u.l mechanisms.
+     */
+    public static void disableDefaultLogHandler(){
+    	LOGGER.removeHandler(HANDLER);	//returns silently if given handler is null or not found
+    }
 
     /**
      * Whether or not logging is enabled.


### PR DESCRIPTION
Keen SDK. This method can be called by applications which wish to more
closely manage log output. 

Closes issue #33.
