### PR TITLE
Extension of KeenCallback interface to support callback execution with detailed information

### DIFF
--- a/core/src/main/java/io/keen/client/java/KeenClient.java
+++ b/core/src/main/java/io/keen/client/java/KeenClient.java
@@ -139,7 +139,8 @@ public class KeenClient {
         }
 
         if (project == null && defaultProject == null) {
-            handleFailure(null, new IllegalStateException("No project specified, but no default project found"));
+            handleFailure(null, project, eventCollection, event, keenProperties,
+            		new IllegalStateException("No project specified, but no default project found"));
             return;
         }
         KeenProject useProject = (project == null ? defaultProject : project);
@@ -151,9 +152,9 @@ public class KeenClient {
 
             // Publish the event.
             publish(useProject, eventCollection, newEvent);
-            handleSuccess(callback);
+            handleSuccess(callback, project, eventCollection, event, keenProperties);
         } catch (Exception e) {
-            handleFailure(callback, e);
+            handleFailure(callback, project, eventCollection, event, keenProperties, e);
         }
     }
 
@@ -201,7 +202,7 @@ public class KeenClient {
         }
 
         if (project == null && defaultProject == null) {
-            handleFailure(null, new IllegalStateException("No project specified, but no default project found"));
+            handleFailure(null, project, eventCollection, event, keenProperties, new IllegalStateException("No project specified, but no default project found"));
             return;
         }
         final KeenProject useProject = (project == null ? defaultProject : project);
@@ -216,7 +217,7 @@ public class KeenClient {
                 }
             });
         } catch (Exception e) {
-            handleFailure(callback, e);
+            handleFailure(callback, project, eventCollection, event, keenProperties, e);
         }
     }
 
@@ -263,7 +264,7 @@ public class KeenClient {
         }
 
         if (project == null && defaultProject == null) {
-            handleFailure(null, new IllegalStateException("No project specified, but no default project found"));
+            handleFailure(null, project, eventCollection, event, keenProperties, new IllegalStateException("No project specified, but no default project found"));
             return;
         }
         KeenProject useProject = (project == null ? defaultProject : project);
@@ -281,9 +282,9 @@ public class KeenClient {
 
             // Save the JSON event out to the event store.
             eventStore.store(useProject.getProjectId(), eventCollection, jsonEvent);
-            handleSuccess(callback);
+            handleSuccess(callback, project, eventCollection, event, keenProperties);
         } catch (Exception e) {
-            handleFailure(callback, e);
+            handleFailure(callback, project, eventCollection, event, keenProperties, e);
         }
     }
 
@@ -1327,6 +1328,35 @@ public class KeenClient {
             }
         }
     }
+    
+
+    /**
+     * Reports success to a callback. If the callback is null, this is a no-op. Any exceptions
+     * thrown by the callback are silently ignored.
+     *
+     * @param callback A callback; may be null.
+     * @param project         The project in which the event was published. If a default project has been set
+     *                        on the client, this parameter may be null, in which case the default project
+     *                        was used.
+     * @param eventCollection The name of the collection in which the event was published
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -> Calendar.getInstance()
+     */
+    private void handleSuccess(KeenCallback callback, KeenProject project, String eventCollection, Map<String, Object> event,
+			Map<String, Object> keenProperties) {
+    	handleSuccess(callback);
+        if (callback != null) {
+            try {
+                if(callback instanceof KeenDetailedCallback){
+                	((KeenDetailedCallback)callback).onSuccess(project, eventCollection, event, keenProperties);
+                }
+            } catch (Exception userException) {
+                // Do nothing.
+            }
+        }
+    }
 
     /**
      * Handles a failure in the Keen library. If the client is running in debug mode, this will
@@ -1349,6 +1379,47 @@ public class KeenClient {
             if (callback != null) {
                 try {
                     callback.onFailure(e);
+                } catch (Exception userException) {
+                    // Do nothing.
+                }
+            }
+        }
+    }
+    
+    /**
+     * Handles a failure in the Keen library. If the client is running in debug mode, this will
+     * immediately throw a runtime exception. Otherwise, this will log an error message and, if the
+     * callback is non-null, call the {@link KeenCallback#onFailure(Exception)} method. Any
+     * exceptions thrown by the callback are silently ignored.
+     *
+     * @param callback A callback; may be null.
+     * @param project         The project in which the event was published. If a default project has been set
+     *                        on the client, this parameter may be null, in which case the default project
+     *                        was used.
+     * @param eventCollection The name of the collection in which the event was published
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -> Calendar.getInstance()
+     * @param e        The exception which caused the failure.
+     */
+    private void handleFailure(KeenCallback callback, KeenProject project, String eventCollection, Map<String, Object> event,
+    			Map<String, Object> keenProperties, Exception e) {
+        if (isDebugMode) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else {
+                throw new RuntimeException(e);
+            }
+        } else {
+        	handleFailure(callback, e);
+        	
+            KeenLogging.log("Encountered error: " + e.getMessage());
+            if (callback != null) {
+                try {
+                    if(callback instanceof KeenDetailedCallback){
+                    	((KeenDetailedCallback)callback).onFailure(project, eventCollection, event, keenProperties, e);
+                    }
                 } catch (Exception userException) {
                     // Do nothing.
                 }

--- a/core/src/main/java/io/keen/client/java/KeenDetailedCallback.java
+++ b/core/src/main/java/io/keen/client/java/KeenDetailedCallback.java
@@ -1,0 +1,49 @@
+package io.keen.client.java;
+
+import java.util.Map;
+
+/**
+ * An interface to allow callers to receive a callback on success or failure of an operation by the
+ * keen client. This is most helpful for asynchronous calls (to detect completion of the
+ * operation), but can also be used to be notified of failures, which are normally caught silently
+ * by the client to prevent application crashes.
+ * 
+ * This advanced version of the callback adds callbacks that take the event details as parameters.
+ * 
+ * @author Mike Reinhold
+ * @since 2.0.3
+ */
+public interface KeenDetailedCallback extends KeenCallback {
+
+    /**
+     * Invoked when the requested operation succeeds.
+     *  
+     * @param project         The project in which the event was published. If a default project has been set
+     *                        on the client, this parameter may be null, in which case the default project
+     *                        was used.
+     * @param eventCollection The name of the collection in which the event was published
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -> Calendar.getInstance()
+     */
+    public void onSuccess(KeenProject project, String eventCollection, Map<String, Object> event,
+            Map<String, Object> keenProperties);
+    
+    /**
+     * Invoked when the requested operation fails.
+     *
+     * @param project         The project in which the event was published. If a default project has been set
+     *                        on the client, this parameter may be null, in which case the default project
+     *                        was used.
+     * @param eventCollection The name of the collection in which the event was published
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -> Calendar.getInstance()
+     * @param e An exception indicating the cause of the failure.
+     */
+    public void onFailure(KeenProject project, String eventCollection, Map<String, Object> event,
+            Map<String, Object> keenProperties, Exception e);
+    
+}


### PR DESCRIPTION
Added an extension to the KeenCallback interface to support callbacks which require additional information in order to perform the necessary activity.

This implementation assumes that the both callback methods should be
called for each event (if the callback is an instance of the
KeenDetailedCallback interface). This implementation calls the KeenCallback
callback method first, then the KeenDetailedCallback callback method
afterward.

Closes issue #32.
