### PR TITLE
Fix bug that posted __attempts.json file as event.

### DIFF
--- a/core/src/main/java/io/keen/client/java/FileEventStore.java
+++ b/core/src/main/java/io/keen/client/java/FileEventStore.java
@@ -259,7 +259,7 @@ public class FileEventStore implements KeenAttemptCountingEventStore {
     private File[] getFilesInDir(File dir) {
         return dir.listFiles(new FileFilter() {
             public boolean accept(File file) {
-                return file.isFile();
+                return file.isFile() && !file.getName().equals(ATTEMPTS_JSON_FILE_NAME);
             }
         });
     }

--- a/core/src/test/java/io/keen/client/java/AttemptCountingEventStoreTestBase.java
+++ b/core/src/test/java/io/keen/client/java/AttemptCountingEventStoreTestBase.java
@@ -3,7 +3,11 @@ package io.keen.client.java;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 /**
@@ -29,5 +33,33 @@ public abstract class AttemptCountingEventStoreTestBase extends EventStoreTestBa
         String attempts = "blargh";
         attemptCountingStore.setAttempts("project1", "collection1", attempts);
         assertEquals(attempts, attemptCountingStore.getAttempts("project1", "collection1"));
+    }
+
+    @Test
+    public void getHandlesWithAttempts() throws Exception {
+        // Add a couple events to the store.
+        attemptCountingStore.store("project1", "collection1", TEST_EVENT_1);
+        attemptCountingStore.store("project1", "collection2", TEST_EVENT_2);
+
+        // set some value for attempts.json. This is to ensure that setting attempts doesn't
+        // interfere with getting handles
+        attemptCountingStore.setAttempts("project1", "collection1", "{}");
+
+        // Get the handle map.
+        Map<String, List<Object>> handleMap = attemptCountingStore.getHandles("project1");
+        assertNotNull(handleMap);
+        assertEquals(2, handleMap.size());
+
+        // Get the lists of handles.
+        List<Object> handles1 = handleMap.get("collection1");
+        assertNotNull(handles1);
+        assertEquals(1, handles1.size());
+        List<Object> handles2 = handleMap.get("collection2");
+        assertNotNull(handles2);
+        assertEquals(1, handles2.size());
+
+        // Validate the actual events.
+        assertEquals(TEST_EVENT_1, attemptCountingStore.get(handles1.get(0)));
+        assertEquals(TEST_EVENT_2, attemptCountingStore.get(handles2.get(0)));
     }
 }


### PR DESCRIPTION
Previously, the SDK would POST the `__attempts.json` as if it were an event because the `FileEventStore.getFilesInDir` private function would return a handle for it. This patch filters out that file.