### PR TITLE
Javadoc syntax fixes

### DIFF
--- a/android/src/main/java/io/keen/client/android/AndroidKeenClientBuilder.java
+++ b/android/src/main/java/io/keen/client/android/AndroidKeenClientBuilder.java
@@ -11,20 +11,22 @@ import io.keen.client.java.KeenNetworkStatusHandler;
 /**
  * {@link io.keen.client.java.KeenClient.Builder} with defaults suited for use on the Android
  * platform.
- * <p/>
+ * <p>
  * This client uses the built-in Android JSON libraries for reading/writing JSON in order to
  * minimize library size. For applications which already include a more robust JSON library such
  * as Jackson or GSON, configure the builder to use an appropriate {@link KeenJsonHandler} via
  * the {@link #withJsonHandler(KeenJsonHandler)} method.
- * <p/>
+ * </p>
+ * <p>
  * To cache events in between batch uploads, this client uses a file-based event store with its
  * root in the application's cache directory. It is important to use a file-based (or
  * otherwise persistent, i.e. non-RAM) event store because the application process could be
  * destroyed without notice.
- * <p/>
+ * </p>
+ * <p>
  * Other defaults are those provided by the parent {@link io.keen.client.java.KeenClient.Builder}
  * implementation.
- * <p/>
+ * </p>
  *
  * @author Kevin Litwack (kevin@kevinlitwack.com)
  * @since 2.0.0

--- a/core/src/main/java/io/keen/client/java/KeenAttemptCountingEventStore.java
+++ b/core/src/main/java/io/keen/client/java/KeenAttemptCountingEventStore.java
@@ -16,6 +16,7 @@ public interface KeenAttemptCountingEventStore extends KeenEventStore {
      * @param projectId the project id
      * @param eventCollection the collection name
      * @return a String that was previously stored for this project and collection or null
+     * @throws java.io.IOException exception
      */
     public String getAttempts(String projectId, String eventCollection) throws IOException;
 
@@ -24,7 +25,8 @@ public interface KeenAttemptCountingEventStore extends KeenEventStore {
      * @param projectId the project id
      * @param eventCollection the collection name
      * @param attemptsString the String to stored for this project and collection
-     */
+     * @throws java.io.IOException exception
+     * */
     public void setAttempts(String projectId, String eventCollection, String attemptsString) throws IOException;
 
 }

--- a/core/src/main/java/io/keen/client/java/KeenClient.java
+++ b/core/src/main/java/io/keen/client/java/KeenClient.java
@@ -102,6 +102,9 @@ public class KeenClient {
      * Adds an event to the default project with default Keen properties and no callbacks.
      *
      * @see #addEvent(KeenProject, String, java.util.Map, java.util.Map, KeenCallback)
+     * @param eventCollection The name of the collection in which to publish the event.
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      */
     public void addEvent(String eventCollection, Map<String, Object> event) {
         addEvent(eventCollection, event, null);
@@ -111,6 +114,11 @@ public class KeenClient {
      * Adds an event to the default project with no callbacks.
      *
      * @see #addEvent(KeenProject, String, java.util.Map, java.util.Map, KeenCallback)
+     * @param eventCollection The name of the collection in which to publish the event.
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      */
     public void addEvent(String eventCollection, Map<String, Object> event,
                          Map<String, Object> keenProperties) {
@@ -128,7 +136,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      * @param callback        An optional callback to receive notification of success or failure.
      */
     public void addEvent(KeenProject project, String eventCollection, Map<String, Object> event,
@@ -163,6 +171,9 @@ public class KeenClient {
      * Adds an event to the default project with default Keen properties and no callbacks.
      *
      * @see #addEvent(KeenProject, String, java.util.Map, java.util.Map, KeenCallback)
+     * @param eventCollection The name of the collection in which to publish the event.
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      */
     public void addEventAsync(String eventCollection, Map<String, Object> event) {
         addEventAsync(eventCollection, event, null);
@@ -172,6 +183,11 @@ public class KeenClient {
      * Adds an event to the default project with no callbacks.
      *
      * @see #addEvent(KeenProject, String, java.util.Map, java.util.Map, KeenCallback)
+     * @param eventCollection The name of the collection in which to publish the event.
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      */
     public void addEventAsync(String eventCollection, Map<String, Object> event,
                               final Map<String, Object> keenProperties) {
@@ -189,7 +205,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      * @param callback        An optional callback to receive notification of success or failure.
      */
     public void addEventAsync(final KeenProject project, final String eventCollection,
@@ -226,6 +242,9 @@ public class KeenClient {
      * Queues an event in the default project with default Keen properties and no callbacks.
      *
      * @see #queueEvent(KeenProject, String, java.util.Map, java.util.Map, KeenCallback)
+     * @param eventCollection The name of the collection in which to publish the event.
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      */
     public void queueEvent(String eventCollection, Map<String, Object> event) {
         queueEvent(eventCollection, event, null);
@@ -235,6 +254,11 @@ public class KeenClient {
      * Queues an event in the default project with no callbacks.
      *
      * @see #queueEvent(KeenProject, String, java.util.Map, java.util.Map, KeenCallback)
+     * @param eventCollection The name of the collection in which to publish the event.
+     * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
+     *                        docs). Nested Maps and lists are acceptable (and encouraged!).
+     * @param keenProperties  A Map that consists of key/value pairs to override default properties.
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      */
     public void queueEvent(String eventCollection, Map<String, Object> event,
                            Map<String, Object> keenProperties) {
@@ -253,7 +277,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      * @param callback        An optional callback to receive notification of success or failure.
      */
     public void queueEvent(KeenProject project, String eventCollection, Map<String, Object> event,
@@ -315,6 +339,9 @@ public class KeenClient {
      * Sends all queued events for the specified project with no callbacks.
      *
      * @see #sendQueuedEvents(KeenProject, KeenCallback)
+     * @param project  The project for which to send queued events. If a default project has been set
+     *                 on the client this parameter may be null, in which case the default project
+     *                 will be used.
      */
     public void sendQueuedEvents(KeenProject project) {
         sendQueuedEvents(project, null);
@@ -382,6 +409,9 @@ public class KeenClient {
      * Sends all queued events for the specified project with no callbacks.
      *
      * @see #sendQueuedEventsAsync(KeenProject, KeenCallback)
+     * @param project  The project for which to send queued events. If a default project has been set
+     *                 on the client this parameter may be null, in which case the default project
+     *                 will be used.
      */
     public void sendQueuedEventsAsync(final KeenProject project) {
         sendQueuedEventsAsync(project, null);
@@ -479,9 +509,9 @@ public class KeenClient {
 
     /**
      * Sets the base API URL associated with this instance of the {@link KeenClient}.
-     * <p/>
+     * <p>
      * Use this if you want to disable SSL.
-     *
+     * </p>
      * @param baseUrl The new base URL (i.e. 'http://api.keen.io'), or null to reset the base URL to
      *                the default ('https://api.keen.io').
      */
@@ -523,19 +553,19 @@ public class KeenClient {
     /**
      * Call this to set the {@link GlobalPropertiesEvaluator} for this instance of the {@link KeenClient}.
      * The evaluator is invoked every time an event is added to an event collection.
-     * <p/>
+     * <p>
      * Global properties are properties which are sent with EVERY event. For example, you may wish to always
      * capture device information like OS version, handset type, orientation, etc.
-     * <p/>
+     * </p> <p>
      * The evaluator takes as a parameter a single String, which is the name of the event collection the
      * event's being added to. You're responsible for returning a Map which represents the global properties
      * for this particular event collection.
-     * <p/>
+     * </p><p>
      * Note that because we use a class defined by you, you can create DYNAMIC global properties. For example,
      * if you want to capture device orientation, then your evaluator can ask the device for its current orientation
      * and then construct the Map. If your global properties aren't dynamic, then just return the same Map
      * every time.
-     * <p/>
+     * </p>
      * Example usage:
      * <pre>
      *     {@code KeenClient client = KeenClient.client();
@@ -569,28 +599,30 @@ public class KeenClient {
     /**
      * Call this to set the Keen Global Properties Map for this instance of the {@link KeenClient}. The Map
      * is used every time an event is added to an event collection.
-     * <p/>
+     * <p>
      * Keen Global Properties are properties which are sent with EVERY event. For example, you may wish to always
      * capture static information like user ID, app version, etc.
-     * <p/>
+     * </p><p>
      * Every time an event is added to an event collection, the SDK will check to see if this property is defined.
      * If it is, the SDK will copy all the properties from the global properties into the newly added event.
-     * <p/>
+     * </p><p>
      * Note that because this is just a Map, it's much more difficult to create DYNAMIC global properties.
      * It also doesn't support per-collection properties. If either of these use cases are important to you, please use
      * the {@link GlobalPropertiesEvaluator}.
-     * <p/>
+     * </p><p>
      * Also note that the Keen properties defined in {@link #getGlobalPropertiesEvaluator()} take precedence over
      * the properties defined in getGlobalProperties, and that the Keen Properties defined in each
      * individual event take precedence over either of the Global Properties.
-     * <p/>
+     * </p><p>
      * Example usage:
-     * <p/>
+     * </p>
      * <pre>
+     *     {@code
      * KeenClient client = KeenClient.client();
      * Map<String, Object> map = new HashMap<String, Object>();
      * map.put("some standard key", "some standard value");
      * client.setGlobalProperties(map);
+     * }
      * </pre>
      *
      * @param globalProperties The new map you wish to use as the Keen Global Properties.
@@ -661,14 +693,14 @@ public class KeenClient {
     /**
      * Builder class for instantiating Keen clients. Subclasses should override this and
      * implement the getDefault* methods to provide new default behavior.
-     * <p/>
+     * <p>
      * This builder doesn't include any default implementation for handling JSON serialization and
      * de-serialization. Subclasses must provide one.
-     * <p/>
+     * </p><p>
      * This builder defaults to using HttpURLConnection to handle HTTP requests.
-     * <p/>
+     * </p><p>
      * To cache events in between batch uploads, this builder defaults to a RAM-based event store.
-     * <p/>
+     * <p>
      * This builder defaults to a fixed thread pool (constructed with
      * {@link java.util.concurrent.Executors#newFixedThreadPool(int)}) to run asynchronous requests.
      */
@@ -1132,6 +1164,7 @@ public class KeenClient {
 
     /**
      * @see #validateEvent(java.util.Map, int)
+     * @param event The event to validate.
      */
     private void validateEvent(Map<String, Object> event) {
         validateEvent(event, 0);
@@ -1491,7 +1524,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      */
     private void handleSuccess(KeenCallback callback, KeenProject project, String eventCollection, Map<String, Object> event,
 			Map<String, Object> keenProperties) {
@@ -1549,7 +1582,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      * @param e        The exception which caused the failure.
      */
     private void handleFailure(KeenCallback callback, KeenProject project, String eventCollection, Map<String, Object> event,

--- a/core/src/main/java/io/keen/client/java/KeenClient.java
+++ b/core/src/main/java/io/keen/client/java/KeenClient.java
@@ -118,7 +118,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      */
     public void addEvent(String eventCollection, Map<String, Object> event,
                          Map<String, Object> keenProperties) {
@@ -136,7 +136,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      * @param callback        An optional callback to receive notification of success or failure.
      */
     public void addEvent(KeenProject project, String eventCollection, Map<String, Object> event,
@@ -187,7 +187,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      */
     public void addEventAsync(String eventCollection, Map<String, Object> event,
                               final Map<String, Object> keenProperties) {
@@ -205,7 +205,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      * @param callback        An optional callback to receive notification of success or failure.
      */
     public void addEventAsync(final KeenProject project, final String eventCollection,
@@ -258,7 +258,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      */
     public void queueEvent(String eventCollection, Map<String, Object> event,
                            Map<String, Object> keenProperties) {
@@ -277,7 +277,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      * @param callback        An optional callback to receive notification of success or failure.
      */
     public void queueEvent(KeenProject project, String eventCollection, Map<String, Object> event,
@@ -1524,7 +1524,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      */
     private void handleSuccess(KeenCallback callback, KeenProject project, String eventCollection, Map<String, Object> event,
 			Map<String, Object> keenProperties) {
@@ -1582,7 +1582,7 @@ public class KeenClient {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      * @param e        The exception which caused the failure.
      */
     private void handleFailure(KeenCallback callback, KeenProject project, String eventCollection, Map<String, Object> event,

--- a/core/src/main/java/io/keen/client/java/KeenDetailedCallback.java
+++ b/core/src/main/java/io/keen/client/java/KeenDetailedCallback.java
@@ -25,7 +25,7 @@ public interface KeenDetailedCallback extends KeenCallback {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      */
     public void onSuccess(KeenProject project, String eventCollection, Map<String, Object> event,
             Map<String, Object> keenProperties);
@@ -40,7 +40,7 @@ public interface KeenDetailedCallback extends KeenCallback {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -> Calendar.getInstance()
+     *                        ex: "timestamp" -&lt; Calendar.getInstance()
      * @param e An exception indicating the cause of the failure.
      */
     public void onFailure(KeenProject project, String eventCollection, Map<String, Object> event,

--- a/core/src/main/java/io/keen/client/java/KeenDetailedCallback.java
+++ b/core/src/main/java/io/keen/client/java/KeenDetailedCallback.java
@@ -25,7 +25,7 @@ public interface KeenDetailedCallback extends KeenCallback {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      */
     public void onSuccess(KeenProject project, String eventCollection, Map<String, Object> event,
             Map<String, Object> keenProperties);
@@ -40,7 +40,7 @@ public interface KeenDetailedCallback extends KeenCallback {
      * @param event           A Map that consists of key/value pairs. Keen naming conventions apply (see
      *                        docs). Nested Maps and lists are acceptable (and encouraged!).
      * @param keenProperties  A Map that consists of key/value pairs to override default properties.
-     *                        ex: "timestamp" -&lt; Calendar.getInstance()
+     *                        ex: "timestamp" -&gt; Calendar.getInstance()
      * @param e An exception indicating the cause of the failure.
      */
     public void onFailure(KeenProject project, String eventCollection, Map<String, Object> event,

--- a/core/src/main/java/io/keen/client/java/KeenJsonHandler.java
+++ b/core/src/main/java/io/keen/client/java/KeenJsonHandler.java
@@ -9,11 +9,11 @@ import java.util.Map;
  * Interface for abstracting the tasks of converting an input {@link java.io.Reader} into an
  * in-memory object (in the form of a {@code Map&lt;String, Object&gt;}), and for writing that
  * object back out to a {@link java.io.Writer}.
- * <p/>
+ * <p>
  * This interface allows the Keen library to be configured to use different JSON implementations
  * in different environments, depending upon requirements for speed versus size (or other
  * considerations).
- *
+ * </p>
  * @author Kevin Litwack (kevin@kevinlitwack.com)
  * @since 2.0.0
  */

--- a/core/src/main/java/io/keen/client/java/KeenJsonHandler.java
+++ b/core/src/main/java/io/keen/client/java/KeenJsonHandler.java
@@ -26,13 +26,13 @@ public interface KeenJsonHandler {
      * Integers, Booleans, etc.), Maps, or Iterables.
      *
      * @param reader The {@link java.io.Reader} from which to read the JSON data.
-     * @return The object which was read, held in a {@code Map&lt;String, Object&gt;}.
+     * @return The object which was read, held in a {@code Map<String, Object>}.
      * @throws IOException If there is an error reading from the input.
      */
     Map<String, Object> readJson(Reader reader) throws IOException;
 
     /**
-     * Writes the given object (in the form of a {@code Map&lt;String, Object&gt;} to the specified
+     * Writes the given object (in the form of a {@code Map<String, Object>} to the specified
      * {@link java.io.Writer}.
      *
      * @param writer The {@link java.io.Writer} to which the JSON data should be written.

--- a/core/src/main/java/io/keen/client/java/KeenNetworkStatusHandler.java
+++ b/core/src/main/java/io/keen/client/java/KeenNetworkStatusHandler.java
@@ -11,7 +11,7 @@ public interface KeenNetworkStatusHandler {
     /**
      * Reports on whether there is a network connection
      *
-     * @return The object which was read, held in a {@code Map&lt;String, Object&gt;}.
+     * @return The object which was read, held in a {@code Map<String, Object>}.
      */
     public boolean isNetworkConnected();
 

--- a/core/src/main/java/io/keen/client/java/KeenNetworkStatusHandler.java
+++ b/core/src/main/java/io/keen/client/java/KeenNetworkStatusHandler.java
@@ -12,7 +12,6 @@ public interface KeenNetworkStatusHandler {
      * Reports on whether there is a network connection
      *
      * @return The object which was read, held in a {@code Map&lt;String, Object&gt;}.
-     * @throws IOException If there is an error reading from the input.
      */
     public boolean isNetworkConnected();
 

--- a/core/src/main/java/io/keen/client/java/RamEventStore.java
+++ b/core/src/main/java/io/keen/client/java/RamEventStore.java
@@ -11,11 +11,11 @@ import java.util.Map;
 /**
  * Implementation of {@link KeenEventStore} which simply keeps a copy of each event in memory until
  * it is explicitly removed.
- * <p/>
+ * <p>
  * NOTE: This implementation synchronizes all operations in order to ensure thread safety, but as
  * a result it may perform poorly under high load. For applications that require high throughput,
  * a custom {@link io.keen.client.java.KeenEventStore} implementation is recommended.
- *
+ * </p>
  * @author Kevin Litwack (kevin@kevinlitwack.com)
  * @since 2.0.0
  */

--- a/core/src/main/java/io/keen/client/java/ScopedKeys.java
+++ b/core/src/main/java/io/keen/client/java/ScopedKeys.java
@@ -16,10 +16,11 @@ import io.keen.client.java.exceptions.ScopedKeyException;
 /**
  * ScopedKeys is a utility class for dealing with Keen IO Scoped Keys. You'll probably only ever need the
  * encrypt method. However, for completeness, there's also a decrypt method.
- * <p/>
+ * <p>
  * Example usage:
- * <p/>
+ * </p>
  * <pre>
+ *     {@code
  *     String apiKey = "YOUR_API_KEY_HERE";
  *
  *     //Filters to apply to the key
@@ -40,6 +41,7 @@ import io.keen.client.java.exceptions.ScopedKeyException;
  *
  *     // do the encryption
  *     String scopedKey = ScopedKeys.encrypt(apiKey, options);
+ *     }
  * </pre>
  *
  * @author dkador
@@ -57,7 +59,7 @@ public class ScopedKeys {
      * @param apiKey  Your Keen IO API Key.
      * @param options The options you want to encrypt.
      * @return A Keen IO Scoped Key.
-     * @throws ScopedKeyException
+     * @throws ScopedKeyException an error occurred while attempting to encrypt a Scoped Key.
      */
     public static String encrypt(String apiKey, Map<String, Object> options)
             throws ScopedKeyException {
@@ -71,7 +73,7 @@ public class ScopedKeys {
      * @param apiKey  Your Keen IO API Key.
      * @param options The options you want to encrypt.
      * @return A Keen IO Scoped Key.
-     * @throws ScopedKeyException
+     * @throws ScopedKeyException an error occurred while attempting to encrypt a Scoped Key.
      */
     public static String encrypt(KeenClient client, String apiKey, Map<String, Object> options)
         throws ScopedKeyException {
@@ -115,7 +117,7 @@ public class ScopedKeys {
      * @param apiKey    Your Keen IO API Key.
      * @param scopedKey The Scoped Key you want to decrypt.
      * @return The decrypted Scoped Key Options.
-     * @throws ScopedKeyException
+     * @throws ScopedKeyException an error occurred while attempting to decrypt a Scoped Key.
      */
     public static Map<String, Object> decrypt(String apiKey, String scopedKey)
             throws ScopedKeyException {
@@ -129,7 +131,7 @@ public class ScopedKeys {
      * @param apiKey    Your Keen IO API Key.
      * @param scopedKey The Scoped Key you want to decrypt.
      * @return The decrypted Scoped Key Options.
-     * @throws ScopedKeyException
+     * @throws ScopedKeyException an error occurred while attempting to decrypt a Scoped Key.
      */
     public static Map<String, Object> decrypt(KeenClient client, String apiKey, String scopedKey)
         throws ScopedKeyException {

--- a/core/src/main/java/io/keen/client/java/http/HttpHandler.java
+++ b/core/src/main/java/io/keen/client/java/http/HttpHandler.java
@@ -13,9 +13,10 @@ public interface HttpHandler {
     /**
      * Executes the given request and returns the received response.
      *
-     * @param request
+     * @param request   The {@link Request} to send.
      * @throws java.io.IOException If there is an error executing the request or processing the
      * response.
+     * @return The {@link Response} received.
      */
     Response execute(Request request) throws IOException;
 

--- a/core/src/main/java/io/keen/client/java/http/OutputSource.java
+++ b/core/src/main/java/io/keen/client/java/http/OutputSource.java
@@ -17,7 +17,7 @@ public interface OutputSource {
     /**
      * Writes data to the given {@link java.io.OutputStream}. This method is used to send the body
      * of an HTTP request.
-     * <p/>
+     * <p>
      * Implementers of this method should NOT close {@code out}; the calling code will ensure
      * that it is closed.
      *

--- a/core/src/main/java/io/keen/client/java/http/UrlConnectionHttpHandler.java
+++ b/core/src/main/java/io/keen/client/java/http/UrlConnectionHttpHandler.java
@@ -81,6 +81,8 @@ public class UrlConnectionHttpHandler implements HttpHandler {
      * Reads a {@link Response} from an existing connection. This method should only be
      * called on a connection for which the entire request has been sent.
      *
+     * @param connection The connection that sent the response.
+     * @return The {@link Response}
      * @throws IOException If there is an error reading the response from the connection.
      */
     protected Response readResponse(HttpURLConnection connection) throws IOException {

--- a/java/src/main/java/io/keen/client/java/JavaKeenClientBuilder.java
+++ b/java/src/main/java/io/keen/client/java/JavaKeenClientBuilder.java
@@ -9,14 +9,14 @@ import java.util.Enumeration;
 /**
  * {@link io.keen.client.java.KeenClient.Builder} with defaults suited for use in a standard Java
  * environment.
- * <p/>
+ * <p>
  * This client uses the Jackson library for reading and writing JSON. As a result, Jackson must be
  * available in order for this library to work properly. For applications which would prefer to
  * use a different JSON library, configure the builder to use an appropriate {@link KeenJsonHandler}
  * via the {@link #withJsonHandler(KeenJsonHandler)} method.
- * <p/>
+ * </p><p>
  * Other defaults are those provided by the parent {@link KeenClient.Builder} implementation.
- * <p/>
+ * </p>
  *
  * @author Kevin Litwack (kevin@kevinlitwack.com)
  * @since 2.0.0


### PR DESCRIPTION
Refers to PR #46 which was closed. This change only affects javadoc syntax and none of the code.

1. Remove self closing <p/> to adhere to HTML 4.
2. @param, @return, @throw fixes
3. < and > need to either be in {@code…} or escaped from (&lt;).